### PR TITLE
chore: add catalog-info.yaml (WK Backstage metadata)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,4 @@
+---
 # Wolters Kluwer Backstage compliant catalog info
 # See https://backstage.io/docs/features/software-catalog/descriptor-format
 apiVersion: backstage.io/v1alpha1
@@ -6,7 +7,7 @@ metadata:
   name: laminas-mime
   description: "Create and parse MIME messages and parts"
   annotations:
-    wolterskluwer.io/bit-id: "041800002496"
+    wolterskluwer.io/bit-id: '041800002496'
 spec:
   type: library
   lifecycle: support

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+# Wolters Kluwer Backstage compliant catalog info
+# See https://backstage.io/docs/features/software-catalog/descriptor-format
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: laminas-mime
+  description: "Create and parse MIME messages and parts"
+  annotations:
+    wolterskluwer.io/bit-id: "041800002496"
+spec:
+  type: library
+  lifecycle: support
+  owner: Glenn.Van-Den-Broeck@wolterskluwer.com


### PR DESCRIPTION
Adds `catalog-info.yaml` at the repo root per the WK Metadata Marker File spec (Backstage-compatible).

- `metadata.name`: repo name
- `metadata.annotations.wolterskluwer.io/bit-id`: extracted from the README `Barometer IT` link (falls back to `041800002496` when not present in README)
- `spec.type`: inferred from repo purpose (service / library / infrastructure / pipeline / documentation / desktop / test-automation)
- `spec.lifecycle`: `production` for customer-facing repos, `support` for repos flagged `[x] non-production code only` in the README or with only SDLC/tooling scope (also `cf-operations`)
- `spec.owner`: `Glenn.Van-Den-Broeck@wolterskluwer.com`
- `links[]`: extracted from the README `## Technical debt links` section (SonarQube = SAST, Black Duck = SCA, Checkmarx = SAST); omitted when the README flags the repo as non-production or SCA-not-applicable

Spec reference: https://confluence.wolterskluwer.io/spaces/DAACCE/pages/934545428/